### PR TITLE
call replaceState not pushState based on flag

### DIFF
--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -268,9 +268,10 @@ const newCopyButton = function() {
   });
 };
 
-const HashState = function(viewer, tileSources, exhibit) {
+const HashState = function(viewer, tileSources, exhibit, options) {
 
   this.resetCount = 0;
+  this.embedded = options.embedded || false;
   this.showdown = new showdown.Converter();
   this.tileSources = tileSources;
   this.exhibit = exhibit;
@@ -945,7 +946,7 @@ HashState.prototype = {
       return;
     }
 
-    if (this.hashKeys === hashKeys) {
+    if (!this.embedded && this.hashKeys === hashKeys) {
       history.pushState(design, title, url);
     }
     else {
@@ -1764,7 +1765,7 @@ const arrange_images = function(viewer, tileSources, state, init) {
   }
 };
 
-const build_page = function(exhibit) {
+const build_page = function(exhibit, embedded) {
 
   // Initialize openseadragon
   const viewer = OpenSeadragon({
@@ -1776,7 +1777,10 @@ const build_page = function(exhibit) {
     homeButton: 'zoom-home',
   });
   const tileSources = {};
-  const state = new HashState(viewer, tileSources, exhibit);
+  const options = {
+    embedded: embedded
+  };
+  const state = new HashState(viewer, tileSources, exhibit, options);
   const init = state.init.bind(state);
   arrange_images(viewer, tileSources, state, init);
 };

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -1765,7 +1765,7 @@ const arrange_images = function(viewer, tileSources, state, init) {
   }
 };
 
-const build_page = function(exhibit, embedded) {
+const build_page = function(exhibit, options) {
 
   // Initialize openseadragon
   const viewer = OpenSeadragon({
@@ -1777,9 +1777,6 @@ const build_page = function(exhibit, embedded) {
     homeButton: 'zoom-home',
   });
   const tileSources = {};
-  const options = {
-    embedded: embedded
-  };
   const state = new HashState(viewer, tileSources, exhibit, options);
   const init = state.init.bind(state);
   arrange_images(viewer, tileSources, state, init);

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -310,7 +310,9 @@
     </script>
     <script>
         const exhibit = {{ exhibit | jsonify }};
-        build_page(exhibit, true);
+        build_page(exhibit, {
+          embedded: true
+        });
     </script>
 
 <script>

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -310,7 +310,7 @@
     </script>
     <script>
         const exhibit = {{ exhibit | jsonify }};
-        build_page(exhibit);
+        build_page(exhibit, true);
     </script>
 
 <script>


### PR DESCRIPTION
This closes #7 

We now call `build_page(exhibit, true)` to start the application in an "embedded" mode. In this mode, we never call `history.pushState`, only `history.replaceState`. 