### PR TITLE
hide openseadragon until all tiles added

### DIFF
--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -339,7 +339,6 @@ HashState.prototype = {
       title: 'Share Link'
     });
 
-
     $('#help').click(this, function(e) {
       const THIS = e.data;
       THIS.s = 0;
@@ -506,6 +505,9 @@ HashState.prototype = {
       ];
       THIS.pushState();
     }, this);
+
+    // Display viewer
+    displayOrNot(this.viewer.element, true);
   },
 
   /*
@@ -1009,9 +1011,7 @@ HashState.prototype = {
     // Redraw design
     if(redraw) {
       // Update OpenSeadragon
-      const viewport = this.viewer.viewport;
-      viewport.panTo(this.viewport.pan);
-      viewport.zoomTo(this.viewport.scale);
+      this.activateViewport();
       newMarkers(this.tileSources, this.group);
       // Redraw HTML Menus
       this.addChannelLegends();
@@ -1288,6 +1288,12 @@ HashState.prototype = {
       THIS.g = g;
       THIS.pushState();
     });
+  },
+
+  activateViewport: function() {
+    const viewport = this.viewer.viewport;
+    viewport.panTo(this.viewport.pan);
+    viewport.zoomTo(this.viewport.scale);
   },
 
   addChannelLegends: function() {
@@ -1736,6 +1742,7 @@ const arrange_images = function(viewer, tileSources, state, init) {
 
               // Initialize hash state
               nLoaded += 1;
+              state.activateViewport();
               if (nLoaded == nTotal) {
                 init();
               }

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -25,7 +25,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col px-0">
-                    <div id="openseadragon1" class="openseadragon"></div>
+                    <div id="openseadragon1" class="d-none openseadragon"></div>
                     <div id="legend" class="position-absolute text-white p-2 bg-trans" style="top: 4rem; right:1.5%">
                         <ul id="channel-legend" class="list-unstyled m-0"></ul>
                     </div>


### PR DESCRIPTION
This closes #6 .

I've set the openseadragon element to bootstrap's `d-none` until all the tiles have been added, which is the soonest that we can set the viewport to the correct position.