### PR TITLE
slow automated animations, keep interaction fast

### DIFF
--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -268,6 +268,18 @@ const newCopyButton = function() {
   });
 };
 
+const changeSprings = function(viewer, seconds, stiffness) {
+  const springs = [
+    'centerSpringX', 'centerSpringY', 'zoomSpring'
+  ];
+  springs.forEach(function(spring) {
+    const s = viewer.viewport[spring];
+    s.animationTime = seconds;
+    s.springStiffness = stiffness;
+    s.springTo(s.target.value);
+  });
+};
+
 const HashState = function(viewer, tileSources, exhibit) {
 
   this.resetCount = 0;
@@ -434,6 +446,12 @@ HashState.prototype = {
       return false;
     });
 
+    this.viewer.addHandler('canvas-enter', function(e) {
+      const THIS = e.userData;
+      THIS.faster();
+      console.log('yo')
+    }, this);
+
     this.viewer.addHandler('canvas-drag', function(e) {
       const THIS = e.userData;
       const overlay = $('#' + THIS.currentOverlay);
@@ -505,6 +523,7 @@ HashState.prototype = {
         round4(pan.y)
       ];
       THIS.pushState();
+      THIS.faster();
     }, this);
   },
 
@@ -669,6 +688,7 @@ HashState.prototype = {
     // Set group, viewport from waypoint
     const waypoint = this.waypoint;
 
+    this.slower();
     this.g = gFromWaypoint(waypoint, this.cgs);
     this.v = vFromWaypoint(waypoint);
     this.o = oFromWaypoint(waypoint);
@@ -1219,6 +1239,13 @@ HashState.prototype = {
         this.drawing = 0;
       }).bind(this), 300);
     }
+  },
+
+  faster: function() {
+    changeSprings(this.viewer, 1.2, 6.4);
+  },
+  slower: function() {
+    changeSprings(this.viewer, 3.2, 6.4);
   },
 
   get currentOverlay() {


### PR DESCRIPTION
This closes #14.

OpenSeadragon itself only allows the global configuration of viewport animation speeds once. So, I wrote a function to manually update the parameters of the private "springs" within the viewport.

 - Animations become slower when switching stories/waypoints
 - Animations return to normal when interacting with Openseadragon

I avoid detecting mouse click, double click, drag, pinch, etc. I simply return the animations to their normal speed whenever the user touches or mouses over the canvas. This also allows impatient users to speed up a slow animation by simply hovering over the viewport. 