### PR TITLE
Fix exhibits.js

### DIFF
--- a/_includes/clipboard.js
+++ b/_includes/clipboard.js
@@ -1,0 +1,46 @@
+// https://gist.github.com/rproenca/64781c6a1329b48a455b645d361a9aa3
+window.Clipboard = (function(window, document, navigator) {
+  var textArea,
+    copy;
+
+  function isiOS() {
+    return navigator.userAgent.match(/ipad|iphone/i);
+  }
+
+  function createTextArea(text) {
+    textArea = document.createElement('textArea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+  }
+
+  function selectText() {
+    var range,
+      selection;
+
+    if (isiOS()) {
+      range = document.createRange();
+      range.selectNodeContents(textArea);
+      selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      textArea.setSelectionRange(0, 999999);
+    } else {
+      textArea.select();
+    }
+  }
+
+  function copyToClipboard() {    
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+  }
+
+  copy = function(text) {
+    createTextArea(text);
+    selectText();
+    copyToClipboard();
+  };
+
+  return {
+    copy: copy
+  };
+})(window, document, navigator);

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -138,13 +138,7 @@ const sort_keys = function(a, b){
 };
 
 const ctrlC = function(str) {
-  const listener = function(e) {
-    e.clipboardData.setData('text/plain', str);
-    e.preventDefault();
-  };
-  document.addEventListener('copy', listener);
-  document.execCommand('copy');
-  document.removeEventListener('copy', listener);
+  Clipboard.copy(str);
 };
 
 const newMarkers = function(tileSources, group) {

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -21,7 +21,12 @@ const encode = function(txt) {
 };
 
 const decode = function(txt) {
-  return decodeURIComponent(atob(txt));
+  try {
+    return decodeURIComponent(atob(txt));
+  }
+  catch (e) {
+    return '';
+  }
 };
 
 const arrayEqual = function(a, b) {

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -352,7 +352,6 @@ HashState.prototype = {
       title: 'Share Link'
     });
 
-
     $('#help').click(this, function(e) {
       const THIS = e.data;
       THIS.s = 0;
@@ -525,6 +524,9 @@ HashState.prototype = {
       THIS.pushState();
       THIS.faster();
     }, this);
+
+    // Display viewer
+    displayOrNot(this.viewer.element, true);
   },
 
   /*
@@ -1029,9 +1031,7 @@ HashState.prototype = {
     // Redraw design
     if(redraw) {
       // Update OpenSeadragon
-      const viewport = this.viewer.viewport;
-      viewport.panTo(this.viewport.pan);
-      viewport.zoomTo(this.viewport.scale);
+      this.activateViewport();
       newMarkers(this.tileSources, this.group);
       // Redraw HTML Menus
       this.addChannelLegends();
@@ -1315,6 +1315,12 @@ HashState.prototype = {
       THIS.g = g;
       THIS.pushState();
     });
+  },
+
+  activateViewport: function() {
+    const viewport = this.viewer.viewport;
+    viewport.panTo(this.viewport.pan);
+    viewport.zoomTo(this.viewport.scale);
   },
 
   addChannelLegends: function() {
@@ -1763,6 +1769,7 @@ const arrange_images = function(viewer, tileSources, state, init) {
 
               // Initialize hash state
               nLoaded += 1;
+              state.activateViewport();
               if (nLoaded == nTotal) {
                 init();
               }

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -267,6 +267,7 @@ const newCopyButton = function() {
   });
 };
 
+<<<<<<< HEAD
 const changeSprings = function(viewer, seconds, stiffness) {
   const springs = [
     'centerSpringX', 'centerSpringY', 'zoomSpring'
@@ -279,9 +280,10 @@ const changeSprings = function(viewer, seconds, stiffness) {
   });
 };
 
-const HashState = function(viewer, tileSources, exhibit) {
+const HashState = function(viewer, tileSources, exhibit, options) {
 
   this.resetCount = 0;
+  this.embedded = options.embedded || false;
   this.showdown = new showdown.Converter();
   this.tileSources = tileSources;
   this.exhibit = exhibit;
@@ -963,7 +965,7 @@ HashState.prototype = {
       return;
     }
 
-    if (this.hashKeys === hashKeys) {
+    if (!this.embedded && this.hashKeys === hashKeys) {
       history.pushState(design, title, url);
     }
     else {
@@ -1789,7 +1791,7 @@ const arrange_images = function(viewer, tileSources, state, init) {
   }
 };
 
-const build_page = function(exhibit) {
+const build_page = function(exhibit, options) {
 
   // Initialize openseadragon
   const viewer = OpenSeadragon({
@@ -1801,7 +1803,7 @@ const build_page = function(exhibit) {
     homeButton: 'zoom-home',
   });
   const tileSources = {};
-  const state = new HashState(viewer, tileSources, exhibit);
+  const state = new HashState(viewer, tileSources, exhibit, options);
   const init = state.init.bind(state);
   arrange_images(viewer, tileSources, state, init);
 };

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -267,7 +267,6 @@ const newCopyButton = function() {
   });
 };
 
-<<<<<<< HEAD
 const changeSprings = function(viewer, seconds, stiffness) {
   const springs = [
     'centerSpringX', 'centerSpringY', 'zoomSpring'
@@ -438,7 +437,7 @@ HashState.prototype = {
       THIS.d = encode(formData.d);
       $('#copy_link_modal').modal('show');
 
-      const root = location.host + location.pathname;
+      const root = THIS.location('host') + THIS.location('pathname');
       const hash = THIS.makeHash(THIS.hashable.tag);
       const link = document.getElementById('copy_link');
       link.value = root + hash;
@@ -532,23 +531,26 @@ HashState.prototype = {
   /*
    * URL History
    */
+  location: function(key) {
+    return decodeURIComponent(location[key]);
+  },
 
   get search() {
-    const search = location.search.slice(1);
+    const search = this.location('search').slice(1);
     const entries = search.split('&');
     return deserialize(entries);
   },
 
   get hash() {
-    const hash = location.hash.slice(1);
+    const hash = this.location('hash').slice(1);
     const entries = hash.split('#');
     return deserialize(entries);
   },
 
   get url() {
-    const root = location.pathname;
-    const search = location.search;
-    const hash = location.hash;
+    const root = this.location('pathname');
+    const search = this.location('search');
+    const hash = this.location('hash');
     return root + search + hash;
   },
 
@@ -1088,7 +1090,7 @@ HashState.prototype = {
   },
 
   makeUrl: function(hashKeys, searchKeys) {
-    const root = location.pathname;
+    const root = this.location('pathname');
     const hash = this.makeHash(hashKeys);
     const search = this.makeSearch(searchKeys);
     return  root + search + hash;

--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -268,6 +268,18 @@ const newCopyButton = function() {
   });
 };
 
+const changeSprings = function(viewer, seconds, stiffness) {
+  const springs = [
+    'centerSpringX', 'centerSpringY', 'zoomSpring'
+  ];
+  springs.forEach(function(spring) {
+    const s = viewer.viewport[spring];
+    s.animationTime = seconds;
+    s.springStiffness = stiffness;
+    s.springTo(s.target.value);
+  });
+};
+
 const HashState = function(viewer, tileSources, exhibit) {
 
   this.resetCount = 0;
@@ -434,6 +446,11 @@ HashState.prototype = {
       return false;
     });
 
+    this.viewer.addHandler('canvas-enter', function(e) {
+      const THIS = e.userData;
+      THIS.faster();
+    }, this);
+
     this.viewer.addHandler('canvas-drag', function(e) {
       const THIS = e.userData;
       const overlay = $('#' + THIS.currentOverlay);
@@ -505,6 +522,7 @@ HashState.prototype = {
         round4(pan.y)
       ];
       THIS.pushState();
+      THIS.faster();
     }, this);
   },
 
@@ -669,6 +687,7 @@ HashState.prototype = {
     // Set group, viewport from waypoint
     const waypoint = this.waypoint;
 
+    this.slower();
     this.g = gFromWaypoint(waypoint, this.cgs);
     this.v = vFromWaypoint(waypoint);
     this.o = oFromWaypoint(waypoint);
@@ -1219,6 +1238,13 @@ HashState.prototype = {
         this.drawing = 0;
       }).bind(this), 300);
     }
+  },
+
+  faster: function() {
+    changeSprings(this.viewer, 1.2, 6.4);
+  },
+  slower: function() {
+    changeSprings(this.viewer, 3.2, 6.4);
   },
 
   get currentOverlay() {

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -306,6 +306,9 @@
         {% include polyfills.js %}
     </script>
     <script>
+        {% include clipboard.js %}
+    </script>
+    <script>
         {% include exhibits.js %}
     </script>
     <script>

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -25,7 +25,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col px-0">
-                    <div id="openseadragon1" class="openseadragon"></div>
+                    <div id="openseadragon1" class="d-none openseadragon"></div>
                     <div id="legend" class="position-absolute text-white p-2 bg-trans" style="top: 4rem; right:1.5%">
                         <ul id="channel-legend" class="list-unstyled m-0"></ul>
                     </div>

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -313,7 +313,9 @@
     </script>
     <script>
         const exhibit = {{ exhibit | jsonify }};
-        build_page(exhibit);
+        build_page(exhibit, {
+          embedded: true
+        });
     </script>
 
 <script>


### PR DESCRIPTION
- Closes #14 with 1e18be4 to slow animations
- Closes #12, closes #4 with 454b06c to fix link-sharing
- Closes #7 with 15f69cc to avoid monopolizing back button
- Closes #6 with 0bff4b0 to fix issues on page load
- Closes #5 with 1f5f0e3 to support url-encoded hash values

#### Issue #14 Resolved

OpenSeadragon itself only allows the global configuration of viewport animation speeds once. So, I wrote a function [here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-a6f501aed54a4cc1393adf7b7e66f579R270) to manually update the parameters of the private "springs" within the viewport.

 - Animations become slower when switching stories/waypoints
 - Animations return to normal when interacting with Openseadragon

I avoid detecting mouse click, double click, drag, pinch, etc. [Here ](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-a6f501aed54a4cc1393adf7b7e66f579R448), I simply return the animations to their normal speed whenever the user touches or mouses over the canvas. This also allows impatient users to speed up a slow animation by simply hovering over the viewport. 

#### Issue #12 Resolved

[Here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-a6f501aed54a4cc1393adf7b7e66f579R24), I catch an exception for incorrectly encoded descriptions in the URL. So, we encode the empty string as "&d=0". When parsing, we raise an exception, and we then return the empty string. 

#### Issue #7 Resolved

[Here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-ccac6804baef0445ef0ab363ff224bc6R316), We now call `build_page(exhibit, {embedded: true})` to start the application in an "embedded" mode. In this mode, we never call `history.pushState`, only `history.replaceState`. 

#### Issue #6 Resolved 

[Here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-ccac6804baef0445ef0ab363ff224bc6R28), I've set the openseadragon element to bootstrap's d-none until all the tiles have been added [here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-a6f501aed54a4cc1393adf7b7e66f579R528), which is the soonest that we can set the viewport to the correct position.

#### Issue #5 Resolved

Instead of directly accessing attributes of window.location, the HashState object provides its own method [here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-a6f501aed54a4cc1393adf7b7e66f579R534) to access the decoded values from the location properties.

#### Issue #4 Resolved
[Here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-f721729c95ab6e3d10437913dc34adb9R2), I simply added clipboard.js from[ a gist ](https://gist.github.com/rproenca/64781c6a1329b48a455b645d361a9aa3)that works for safari and chrome. I reference that [here](https://github.com/sorgerlab/cycif.org/pull/16/files#diff-a6f501aed54a4cc1393adf7b7e66f579R146).