### PR TITLE
Fix issue with label alignment 

### DIFF
--- a/_includes/exhibits.js
+++ b/_includes/exhibits.js
@@ -287,6 +287,7 @@ const HashState = function(viewer, tileSources, exhibit, options) {
   this.tileSources = tileSources;
   this.exhibit = exhibit;
   this.viewer = viewer;
+  viewer.setVisible(false);
 
   this.hashable = {
     exhibit: [
@@ -525,7 +526,8 @@ HashState.prototype = {
     }, this);
 
     // Display viewer
-    displayOrNot(this.viewer.element, true);
+    this.finishAnimation();
+    this.viewer.setVisible(true);
   },
 
   /*
@@ -1243,6 +1245,10 @@ HashState.prototype = {
     }
   },
 
+  finishAnimation: function() {
+    const target = this.viewer.viewport.getBounds();
+    this.viewer.viewport.fitBounds(target, true);
+  },
   faster: function() {
     changeSprings(this.viewer, 1.2, 6.4);
   },
@@ -1771,7 +1777,6 @@ const arrange_images = function(viewer, tileSources, state, init) {
 
               // Initialize hash state
               nLoaded += 1;
-              state.activateViewport();
               if (nLoaded == nTotal) {
                 init();
               }

--- a/_layouts/osd-exhibit.html
+++ b/_layouts/osd-exhibit.html
@@ -25,7 +25,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col px-0">
-                    <div id="openseadragon1" class="d-none openseadragon"></div>
+                    <div id="openseadragon1" class="openseadragon"></div>
                     <div id="legend" class="position-absolute text-white p-2 bg-trans" style="top: 4rem; right:1.5%">
                         <ul id="channel-legend" class="list-unstyled m-0"></ul>
                     </div>


### PR DESCRIPTION
This closes #19 

When preventing OpenSeadragon from jittering between multiple viewports, the previous bootstrap-based solution caused incorrectly aligned labels overlays for each image in the viewport.

Now, we use openseadragon's internal `setVisible` method. We also call a function to quickly finish the animation immediately before displaying the viewer. Because we now make no changes to the visibility of the actual HTML element containing openseadragon, openseadragon has no problem correctly aligning the labels.